### PR TITLE
New Gang Fix

### DIFF
--- a/pawn/Entities/Gangs/GangCommands.pwn
+++ b/pawn/Entities/Gangs/GangCommands.pwn
@@ -245,11 +245,11 @@ class GangCommands {
                 return 1;
             }
         }
-        
+
         // Checks if the user is ALREADY in any gang.
- 		if (GangPlayer(playerId)->gangId() == Gang::InvalidId) {
- 			Gang(gangId)->onPlayerLeave(playerId);
- 		}
+        if (GangPlayer(playerId)->gangId() == Gang::InvalidId) {
+            Gang(gangId)->onPlayerLeave(playerId);
+        }
 
         // Join the gang. The Gang::onPlayerJoin() message will announce it to the gang and set up
         // to player's state to make sure they're member of the gang.

--- a/pawn/Entities/Gangs/GangCommands.pwn
+++ b/pawn/Entities/Gangs/GangCommands.pwn
@@ -246,9 +246,10 @@ class GangCommands {
             }
         }
 
-        // Checks if the user is ALREADY in any gang.
-        if (GangPlayer(playerId)->gangId() == Gang::InvalidId) {
-            Gang(gangId)->onPlayerLeave(playerId);
+        // Checks if the user is already in any gang. If they are, remove them from
+        // first gang and allow them to join new gang.
+        if (GangPlayer(playerId)->gangId() != Gang::InvalidId) {
+            Gang(GangPlayer(playerId)->gangId())->onPlayerLeave(playerId);
         }
 
         // Join the gang. The Gang::onPlayerJoin() message will announce it to the gang and set up

--- a/pawn/Entities/Gangs/GangCommands.pwn
+++ b/pawn/Entities/Gangs/GangCommands.pwn
@@ -245,6 +245,11 @@ class GangCommands {
                 return 1;
             }
         }
+        
+        // Checks if the user is ALREADY in any gang.
+ 		if (GangPlayer(playerId)->gangId() == Gang::InvalidId) {
+ 			Gang(gangId)->onPlayerLeave(playerId);
+ 		}
 
         // Join the gang. The Gang::onPlayerJoin() message will announce it to the gang and set up
         // to player's state to make sure they're member of the gang.

--- a/pawn/Entities/Gangs/GangCommands.pwn
+++ b/pawn/Entities/Gangs/GangCommands.pwn
@@ -211,6 +211,7 @@ class GangCommands {
     @switch(GangCommand, "join")
     public onGangJoinCommand(playerId, params[]) {
         new gangId = Gang::InvalidId;
+        new playerGangId = GangPlayer(playerId)->gangId();
 
         // If a parameter has been given, it might be an administrator forcefully joining a gang.
         if (Command->parameterCount(params) != 0) {
@@ -248,8 +249,8 @@ class GangCommands {
 
         // Checks if the user is already in any gang. If they are, remove them from
         // first gang and allow them to join new gang.
-        if (GangPlayer(playerId)->gangId() != Gang::InvalidId) {
-            Gang(GangPlayer(playerId)->gangId())->onPlayerLeave(playerId);
+        if (playerGangId != Gang::InvalidId) {
+            Gang(playerGangId)->onPlayerLeave(playerId);
         }
 
         // Join the gang. The Gang::onPlayerJoin() message will announce it to the gang and set up


### PR DESCRIPTION
Indent was once again wrong, although saved with proper indent.

There are two extra commits to this PR, not sure why. gangFix needs implemented and gangJoinFix can be trashed. Take it easy on me, I'm the new guy.

Fix:
This simply kicks players from their current gangs before joining to another one. 
This case is currently possible only for admins, as they can join gangs without requests, which gives a wrong player count to his previous gang. (Fix by MasterKc12)
