### PR TITLE
Make it able to turn on/off players engines

### DIFF
--- a/javascript/features/playground/commands/engine.js
+++ b/javascript/features/playground/commands/engine.js
@@ -1,0 +1,44 @@
+// Copyright 2020 Las Venturas Playground. All rights reserved.
+// Use of this source code is governed by the MIT license, a copy of which can
+// be found in the LICENSE file.
+
+import Command from 'features/playground/command.js';
+import CommandBuilder from 'components/command_manager/command_builder.js';
+
+// Command: /engine [player]
+export default class EngineCommand extends Command {
+    get name() { return 'engine'; }
+    get defaultPlayerLevel() { return Player.LEVEL_MANAGEMENT; }
+
+    build(commandBuilder) {
+        commandBuilder
+            .parameters([{ name: 'target', type: CommandBuilder.PLAYER_PARAMETER }])
+            .build(EngineCommand.prototype.onEngineCommand.bind(this));
+    }
+
+    // Turn on or off the engine for the target.
+    onEngineCommand(player, target) {
+        const vehicleId = pawnInvoke('GetPlayerVehicleID', 'i', target.id);
+        if (vehicleId == 0 || vehicleId > 3000) {
+            player.sendMessage(Message.COMMAND_ERROR, target.name + ' is not driving a vehicle.');
+            return;
+        }
+
+        const vehicleParams = pawnInvoke('GetVehicleParamsEx', 'iIIIIIII', vehicleId);    
+        
+        if(vehicleParams[0] === 1) {
+            player.sendMessage(Message.COMMAND_SUCCESS, target.name + 
+                '\'s engine has been turned off.');
+            vehicleParams[0] = 0;
+        } else {
+            player.sendMessage(Message.COMMAND_SUCCESS, target.name + 
+                '\'s engine has been turned on.');
+                vehicleParams[0] = 1;         
+        }
+
+        pawnInvoke('SetVehicleParamsEx', 'iiiiiiii', vehicleId, vehicleParams[0], vehicleParams[1], 
+            vehicleParams[2], vehicleParams[3], vehicleParams[4], vehicleParams[5], 
+            vehicleParams[6]);
+    }
+
+}

--- a/javascript/features/playground/commands/engine.js
+++ b/javascript/features/playground/commands/engine.js
@@ -33,7 +33,7 @@ export default class EngineCommand extends Command {
         } else {
             player.sendMessage(Message.COMMAND_SUCCESS, target.name + 
                 '\'s engine has been turned on.');
-                vehicleParams[0] = 1;         
+            vehicleParams[0] = 1;         
         }
 
         pawnInvoke('SetVehicleParamsEx', 'iiiiiiii', vehicleId, vehicleParams[0], vehicleParams[1], 

--- a/javascript/features/playground/playground_commands.js
+++ b/javascript/features/playground/playground_commands.js
@@ -70,6 +70,7 @@ class PlaygroundCommands {
         const commandFiles = [
             'features/playground/commands/autohello.js',
             'features/playground/commands/boost.js',
+            'features/playground/commands/engine.js',
             'features/playground/commands/fancy.js',
             'features/playground/commands/fly.js',
             'features/playground/commands/jetpack.js',


### PR DESCRIPTION
Thank you for making a contribution to [Las Venturas Playground](https://sa-mp.nl/)!

Please take a moment to fill in the questions in this template, to make it easier for our developers
to understand what you're doing.

## What is being changed?
_Add the engine command to the playground feature. Enables managers to enable/disable engines of a car._

## Why is this being changed?
_Because sometimes it can be fun to mess with people._

## How are you making the change?
  [X] I have a working check-out of Las Venturas Playground.
  [X] I have included tests for any changed JavaScript code.
  [ ] I have tested this change myself on my local server. --> It's too small and tightly coupled with pawnInvoke.
