### PR TITLE
make it possible to use indicators on cars

### DIFF
--- a/javascript/entities/vehicle.js
+++ b/javascript/entities/vehicle.js
@@ -15,7 +15,7 @@ class Vehicle {
     static kVehicleKeysJump = 16;
     static kVehicleKeysNos = 32;
     static kVehicleKeysBlinkerRight = 64;
-    static kVehicleKeysBlinkerLeft = 256;
+    static kVehicleKeysBlinkerLeft = 128;
 
     constructor(manager, options) {
         this.manager_ = manager;

--- a/javascript/entities/vehicle.js
+++ b/javascript/entities/vehicle.js
@@ -14,6 +14,8 @@ class Vehicle {
     static kVehicleKeysFlip = 8;
     static kVehicleKeysJump = 16;
     static kVehicleKeysNos = 32;
+    static kVehicleKeysBlinkerRight = 64;
+    static kVehicleKeysBlinkerLeft = 256;
 
     constructor(manager, options) {
         this.manager_ = manager;

--- a/javascript/features/playground/commands/indicators.js
+++ b/javascript/features/playground/commands/indicators.js
@@ -21,8 +21,8 @@ export default class IndicatorsCommand extends Command {
         const subject = target || player;
 
         if (subject.syncedData.vehicleKeys & Vehicle.kVehicleKeysBlinkerRight) {
-            subject.syncedData.vehicleKeys &= Vehicle.kVehicleKeysBlinkerRight;
-            subject.syncedData.vehicleKeys &= Vehicle.kVehicleKeysBlinkerLeft;
+            subject.syncedData.vehicleKeys &= ~ Vehicle.kVehicleKeysBlinkerRight;
+            subject.syncedData.vehicleKeys &= ~ Vehicle.kVehicleKeysBlinkerLeft;
             
             player.sendMessage(Message.COMMAND_SUCCESS, subject.name + ' can\'t use the blinkers anymore.');
             return;

--- a/javascript/features/playground/commands/indicators.js
+++ b/javascript/features/playground/commands/indicators.js
@@ -1,0 +1,199 @@
+// Copyright 2020 Las Venturas Playground. All rights reserved.
+// Use of this source code is governed by the MIT license, a copy of which can
+// be found in the LICENSE file.
+
+import Command from 'features/playground/command.js';
+import CommandBuilder from 'components/command_manager/command_builder.js';
+
+// Indicates how often we check for the player keys 
+const FramesPerSecond = 10;
+
+// Command: /indicator [player]
+export default class IndicatorCommand extends Command {
+    constructor(...args) {
+        super(...args);
+
+        this.indicating_ = new Map();
+
+        server.playerManager.addObserver(this, true /* replayHistory */);
+    }
+
+    get name() { return 'indicator'; }
+    get defaultPlayerLevel() { return Player.LEVEL_MANAGEMENT; }
+
+    build(commandBuilder) {
+        commandBuilder
+            .parameters([{ name: 'target', type: CommandBuilder.PLAYER_PARAMETER, optional: true }])
+            .build(IndicatorCommand.prototype.onIndicatorCommand.bind(this));
+    }
+
+    // Turn on or off the ability to use indicators.
+    async onIndicatorCommand(player, target) {
+        const subject = target || player;
+
+        if (this.indicating_.has(subject)) {
+            this.stopIndicating(subject);
+            this.indicating_.delete(player);
+            player.sendMessage(Message.COMMAND_SUCCESS, subject + ' can\'t use the blinkers anymore.');
+            return;
+        }
+
+        player.sendMessage(Message.COMMAND_SUCCESS, subject + ' will now able to use the blinkers.');
+        this.indicating_.set(subject, {});
+        while (this.indicating_.has(subject) && subject.isConnected()) {
+            const keys = this.getPlayerKeys(player);
+
+            this.playerKeyUpdate(player, keys, this.indicating_.get(subject).oldKey);
+
+            await seconds(1 / FramesPerSecond);
+        }
+    }
+
+    // |Player| left the vehicle so cleanup. Keep him in the map though.
+    onPlayerLeaveVehicle(player) {
+        this.stopIndicating(player);
+    }
+
+    // |Player| disconnected so cleanup.
+    onPlayerDisconnect(player) {
+        this.stopIndicating(player);
+        this.indicating_.delete(player);
+    }
+
+    // Check if |player| is pressing numpad 4/6 and didn't before. Update blinkers accordingly.
+    playerKeyUpdate(player, newKey, oldKey) {
+        if (!this.indicating_.has(player)) {
+            return;
+        }
+
+        const vehicle = player.vehicle;
+        if (!vehicle) { //Player not in a vehicle or not managed by JS.
+            return;
+        }
+
+        if (this.isPlaneOrBoat(vehicle.model.id)) {
+            return;
+        }
+
+        const hasOldQ = oldKey & 8192; // Numpad 4
+        const hasNewQ = newKey & 8192;
+        const hasOldE = oldKey & 16384; // Numpad 6
+        const hasNewE = newKey & 16384;
+
+        let left, right;
+        if (hasNewQ && !hasOldQ) { // Player now pressed Q
+            left = !this.indicating_.get(player).leftFront > 0;
+        }
+        else {
+            left = this.indicating_.get(player).leftFront > 0;
+        }
+
+        if (hasNewE && !hasOldE) { // Player now pressed E
+            right = !this.indicating_.get(player).rightFront > 0;
+        }
+        else {
+            right = this.indicating_.get(player).rightFront > 0;
+        }
+
+        this.setBlinker(player, left, right, newKey);
+    }
+
+    // Change the state of the blinkers for the |player|
+    setBlinker(player, left, right, newKey) {
+        const blinkerModel = 19294;
+        const vehicleId = player.vehicle.id;
+        const sizes = pawnInvoke('GetVehicleModelInfo', 'iiFFF', player.vehicle.model.id, 1 /* size */);
+
+        const items = this.indicating_.get(player);
+
+        if (right) {
+            if (!items.rightFront > 0) {
+                items.rightFront = pawnInvoke('CreateObject', 'ifffffff', blinkerModel, 0, 0, 0, 0, 0, 0, 0);
+                pawnInvoke('AttachObjectToVehicle', 'iiffffff', items.rightFront, vehicleId,
+                    sizes[0] / 2.23, sizes[1] / 2.23, 0.1, 0, 0, 0);
+
+                items.rightBack = pawnInvoke('CreateObject', 'ifffffff', blinkerModel, 0, 0, 0, 0, 0, 0, 0);
+                pawnInvoke('AttachObjectToVehicle', 'iiffffff', items.rightBack, vehicleId,
+                    sizes[0] / 2.23, -sizes[1] / 2.23, 0.1, 0, 0, 0);
+            }
+        } else {
+            if (items.rightFront > 0) {
+                pawnInvoke('DestroyObject', 'i', items.rightFront);
+                items.rightFront = 0;
+            }
+            if (items.rightBack > 0) {
+                pawnInvoke('DestroyObject', 'i', items.rightBack);
+                items.rightBack = 0;
+            }
+        }
+
+        if (left) {
+            if (!items.leftFront > 0) {
+                items.leftFront = pawnInvoke('CreateObject', 'ifffffff', blinkerModel, 0, 0, 0, 0, 0, 0, 0);
+                pawnInvoke('AttachObjectToVehicle', 'iiffffff', items.leftFront, vehicleId,
+                    -sizes[0] / 2.23, sizes[1] / 2.23, 0.1, 0, 0, 0);
+
+                items.leftBack = pawnInvoke('CreateObject', 'ifffffff', blinkerModel, 0, 0, 0, 0, 0, 0, 0);
+                pawnInvoke('AttachObjectToVehicle', 'iiffffff', items.leftBack, vehicleId,
+                    -sizes[0] / 2.23, -sizes[1] / 2.23, 0.1, 0, 0, 0);
+            }
+        } else {
+            if (items.leftFront > 0) {
+                pawnInvoke('DestroyObject', 'i', items.leftFront);
+                items.leftFront = 0;
+            }
+            if (items.leftBack > 0) {
+                pawnInvoke('DestroyObject', 'i', items.leftBack);
+                items.leftBack = 0;
+            }
+        }
+
+        items.oldKey = newKey;
+        this.indicating_.set(player, items);
+    }
+
+    // Make the |player|'s blinkers stop and unable to use again.
+    stopIndicating(player) {
+        if (!this.indicating_.has(player)) {
+            return;
+        }
+
+        // Vehicle is not managed by JavaScript.
+        if (!player.vehicle) {
+            return;
+        }
+
+        this.setBlinker(player, false, false, null);
+    }
+
+    // Utility function to get a labelled version of the keys the player is pressing.
+    getPlayerKeys(player) {
+        const [keys, updown, leftright] = pawnInvoke('GetPlayerKeys', 'iIII', player.id);
+        return keys;
+    }
+
+    // Determines whether the model is a plane or a bout (not supported).
+    isPlaneOrBoat(modelId) {
+        // Planes
+        if (modelId == 460 || modelId == 476 || modelId == 511 || modelId == 512 || modelId == 513 ||
+            modelId == 519 || modelId == 520 || modelId == 553 || modelId == 577 || modelId == 592 ||
+            modelId == 593)
+            return true;
+
+        // Boats
+        if (modelId == 430 || modelId == 446 || modelId == 452 || modelId == 453 || modelId == 454 ||
+            modelId == 472 || modelId == 473 || modelId == 484 || modelId == 493 || modelId == 595)
+            return true;
+
+        return false;
+    }
+
+    dispose() {
+        for (const player of this.indicating_.keys()) {
+            this.stopIndicating(player);
+        }
+
+        this.indicating_ = null;
+    }
+
+}

--- a/javascript/features/playground/commands/indicators.js
+++ b/javascript/features/playground/commands/indicators.js
@@ -5,195 +5,31 @@
 import Command from 'features/playground/command.js';
 import CommandBuilder from 'components/command_manager/command_builder.js';
 
-// Indicates how often we check for the player keys 
-const FramesPerSecond = 10;
-
-// Command: /indicator [player]
-export default class IndicatorCommand extends Command {
-    constructor(...args) {
-        super(...args);
-
-        this.indicating_ = new Map();
-
-        server.playerManager.addObserver(this, true /* replayHistory */);
-    }
-
-    get name() { return 'indicator'; }
+// Command: /indicators [player]
+export default class IndicatorsCommand extends Command {
+    get name() { return 'indicators'; }
     get defaultPlayerLevel() { return Player.LEVEL_MANAGEMENT; }
 
     build(commandBuilder) {
         commandBuilder
             .parameters([{ name: 'target', type: CommandBuilder.PLAYER_PARAMETER, optional: true }])
-            .build(IndicatorCommand.prototype.onIndicatorCommand.bind(this));
+            .build(IndicatorsCommand.prototype.onIndicatorCommand.bind(this));
     }
 
     // Turn on or off the ability to use indicators.
     async onIndicatorCommand(player, target) {
         const subject = target || player;
 
-        if (this.indicating_.has(subject)) {
-            this.stopIndicating(subject);
-            this.indicating_.delete(player);
-            player.sendMessage(Message.COMMAND_SUCCESS, subject + ' can\'t use the blinkers anymore.');
+        if (subject.syncedData.vehicleKeys & Vehicle.kVehicleKeysBlinkerRight) {
+            subject.syncedData.vehicleKeys &= Vehicle.kVehicleKeysBlinkerRight;
+            subject.syncedData.vehicleKeys &= Vehicle.kVehicleKeysBlinkerLeft;
+            
+            player.sendMessage(Message.COMMAND_SUCCESS, subject.name + ' can\'t use the blinkers anymore.');
             return;
         }
-
-        player.sendMessage(Message.COMMAND_SUCCESS, subject + ' will now able to use the blinkers.');
-        this.indicating_.set(subject, {});
-        while (this.indicating_.has(subject) && subject.isConnected()) {
-            const keys = this.getPlayerKeys(player);
-
-            this.playerKeyUpdate(player, keys, this.indicating_.get(subject).oldKey);
-
-            await seconds(1 / FramesPerSecond);
-        }
+        
+        subject.syncedData.vehicleKeys |= Vehicle.kVehicleKeysBlinkerRight;
+        subject.syncedData.vehicleKeys |= Vehicle.kVehicleKeysBlinkerLeft;
+        player.sendMessage(Message.COMMAND_SUCCESS, subject.name + ' will now able to use the blinkers.');
     }
-
-    // |Player| left the vehicle so cleanup. Keep him in the map though.
-    onPlayerLeaveVehicle(player) {
-        this.stopIndicating(player);
-    }
-
-    // |Player| disconnected so cleanup.
-    onPlayerDisconnect(player) {
-        this.stopIndicating(player);
-        this.indicating_.delete(player);
-    }
-
-    // Check if |player| is pressing numpad 4/6 and didn't before. Update blinkers accordingly.
-    playerKeyUpdate(player, newKey, oldKey) {
-        if (!this.indicating_.has(player)) {
-            return;
-        }
-
-        const vehicle = player.vehicle;
-        if (!vehicle) { //Player not in a vehicle or not managed by JS.
-            return;
-        }
-
-        if (this.isPlaneOrBoat(vehicle.model.id)) {
-            return;
-        }
-
-        const hasOldQ = oldKey & 8192; // Numpad 4
-        const hasNewQ = newKey & 8192;
-        const hasOldE = oldKey & 16384; // Numpad 6
-        const hasNewE = newKey & 16384;
-
-        let left, right;
-        if (hasNewQ && !hasOldQ) { // Player now pressed Q
-            left = !this.indicating_.get(player).leftFront > 0;
-        }
-        else {
-            left = this.indicating_.get(player).leftFront > 0;
-        }
-
-        if (hasNewE && !hasOldE) { // Player now pressed E
-            right = !this.indicating_.get(player).rightFront > 0;
-        }
-        else {
-            right = this.indicating_.get(player).rightFront > 0;
-        }
-
-        this.setBlinker(player, left, right, newKey);
-    }
-
-    // Change the state of the blinkers for the |player|
-    setBlinker(player, left, right, newKey) {
-        const blinkerModel = 19294;
-        const vehicleId = player.vehicle.id;
-        const sizes = pawnInvoke('GetVehicleModelInfo', 'iiFFF', player.vehicle.model.id, 1 /* size */);
-
-        const items = this.indicating_.get(player);
-
-        if (right) {
-            if (!items.rightFront > 0) {
-                items.rightFront = pawnInvoke('CreateObject', 'ifffffff', blinkerModel, 0, 0, 0, 0, 0, 0, 0);
-                pawnInvoke('AttachObjectToVehicle', 'iiffffff', items.rightFront, vehicleId,
-                    sizes[0] / 2.23, sizes[1] / 2.23, 0.1, 0, 0, 0);
-
-                items.rightBack = pawnInvoke('CreateObject', 'ifffffff', blinkerModel, 0, 0, 0, 0, 0, 0, 0);
-                pawnInvoke('AttachObjectToVehicle', 'iiffffff', items.rightBack, vehicleId,
-                    sizes[0] / 2.23, -sizes[1] / 2.23, 0.1, 0, 0, 0);
-            }
-        } else {
-            if (items.rightFront > 0) {
-                pawnInvoke('DestroyObject', 'i', items.rightFront);
-                items.rightFront = 0;
-            }
-            if (items.rightBack > 0) {
-                pawnInvoke('DestroyObject', 'i', items.rightBack);
-                items.rightBack = 0;
-            }
-        }
-
-        if (left) {
-            if (!items.leftFront > 0) {
-                items.leftFront = pawnInvoke('CreateObject', 'ifffffff', blinkerModel, 0, 0, 0, 0, 0, 0, 0);
-                pawnInvoke('AttachObjectToVehicle', 'iiffffff', items.leftFront, vehicleId,
-                    -sizes[0] / 2.23, sizes[1] / 2.23, 0.1, 0, 0, 0);
-
-                items.leftBack = pawnInvoke('CreateObject', 'ifffffff', blinkerModel, 0, 0, 0, 0, 0, 0, 0);
-                pawnInvoke('AttachObjectToVehicle', 'iiffffff', items.leftBack, vehicleId,
-                    -sizes[0] / 2.23, -sizes[1] / 2.23, 0.1, 0, 0, 0);
-            }
-        } else {
-            if (items.leftFront > 0) {
-                pawnInvoke('DestroyObject', 'i', items.leftFront);
-                items.leftFront = 0;
-            }
-            if (items.leftBack > 0) {
-                pawnInvoke('DestroyObject', 'i', items.leftBack);
-                items.leftBack = 0;
-            }
-        }
-
-        items.oldKey = newKey;
-        this.indicating_.set(player, items);
-    }
-
-    // Make the |player|'s blinkers stop and unable to use again.
-    stopIndicating(player) {
-        if (!this.indicating_.has(player)) {
-            return;
-        }
-
-        // Vehicle is not managed by JavaScript.
-        if (!player.vehicle) {
-            return;
-        }
-
-        this.setBlinker(player, false, false, null);
-    }
-
-    // Utility function to get a labelled version of the keys the player is pressing.
-    getPlayerKeys(player) {
-        const [keys, updown, leftright] = pawnInvoke('GetPlayerKeys', 'iIII', player.id);
-        return keys;
-    }
-
-    // Determines whether the model is a plane or a bout (not supported).
-    isPlaneOrBoat(modelId) {
-        // Planes
-        if (modelId == 460 || modelId == 476 || modelId == 511 || modelId == 512 || modelId == 513 ||
-            modelId == 519 || modelId == 520 || modelId == 553 || modelId == 577 || modelId == 592 ||
-            modelId == 593)
-            return true;
-
-        // Boats
-        if (modelId == 430 || modelId == 446 || modelId == 452 || modelId == 453 || modelId == 454 ||
-            modelId == 472 || modelId == 473 || modelId == 484 || modelId == 493 || modelId == 595)
-            return true;
-
-        return false;
-    }
-
-    dispose() {
-        for (const player of this.indicating_.keys()) {
-            this.stopIndicating(player);
-        }
-
-        this.indicating_ = null;
-    }
-
 }

--- a/javascript/features/playground/playground_commands.js
+++ b/javascript/features/playground/playground_commands.js
@@ -74,6 +74,7 @@ class PlaygroundCommands {
             'features/playground/commands/fancy.js',
             'features/playground/commands/flap.js',
             'features/playground/commands/fly.js',
+            'features/playground/commands/indicators.js',
             'features/playground/commands/jetpack.js',
             'features/playground/commands/kickflip.js',
             'features/playground/commands/player_settings.js',

--- a/pawn/Driver/Driver.pwn
+++ b/pawn/Driver/Driver.pwn
@@ -243,8 +243,8 @@ public OnPlayerKeyStateChange(playerid, newkeys, oldkeys) {
             PRESSED(VEHICLE_KEYS_BINDING_BLINKER_LEFT) && vehicleKeys & VEHICLE_KEYS_BLINKER_LEFT;
 
         if(pressedBlinkerRight || pressedBlinkerLeft) {
-            new const bool: blinkingOnRight = g_blinkerObjects[playerid][0] != DynamicObject: INVALID_OBJECT_ID;
-            new const bool: blinkingOnLeft = g_blinkerObjects[playerid][2] != DynamicObject: INVALID_OBJECT_ID;
+            new const bool: blinkingOnRight = IsValidDynamicObject(g_blinkerObjects[playerid][0]) == 1;
+            new const bool: blinkingOnLeft = IsValidDynamicObject(g_blinkerObjects[playerid][2]) == 1;
 
             new const bool: rightBlinker = pressedBlinkerRight ? !blinkingOnRight : blinkingOnRight;
             new const bool: leftBlinker = pressedBlinkerLeft ? !blinkingOnLeft : blinkingOnLeft;
@@ -262,7 +262,7 @@ SetBlinker(playerid, vehicleId, bool:left, bool:right) {
     new const blinkerModel = 19294;
     new const modelId = GetVehicleModel(vehicleId);
 
-    if(VehicleModel(modelId)->isNitroInjectionAvailable()) {
+    if(!VehicleModel(modelId)->isNitroInjectionAvailable()) {
         return;
     }
 
@@ -270,7 +270,7 @@ SetBlinker(playerid, vehicleId, bool:left, bool:right) {
     GetVehicleModelInfo(modelId, VEHICLE_MODEL_INFO_SIZE, sizeX, sizeY, sizeZ);
 
     if (right) {
-        if (g_blinkerObjects[playerid][0] == DynamicObject: INVALID_OBJECT_ID) {
+        if (!IsValidDynamicObject(g_blinkerObjects[playerid][0])) {
             g_blinkerObjects[playerid][0] = CreateDynamicObject(blinkerModel, 0, 0, 0, 0, 0, 0);
             AttachDynamicObjectToVehicle(g_blinkerObjects[playerid][0], vehicleId, sizeX/2.23, sizeY/2.23, 
                 0.1, 0, 0, 0);
@@ -285,7 +285,7 @@ SetBlinker(playerid, vehicleId, bool:left, bool:right) {
     }
 
     if (left) {
-        if (g_blinkerObjects[playerid][2] == DynamicObject: INVALID_OBJECT_ID) {
+        if (!IsValidDynamicObject(g_blinkerObjects[playerid][2])) {
             g_blinkerObjects[playerid][2] = CreateDynamicObject(blinkerModel, 0, 0, 0, 0, 0, 0);
             AttachDynamicObjectToVehicle(g_blinkerObjects[playerid][2], vehicleId, -sizeX/2.23, sizeY/2.23, 
                 0.1, 0, 0, 0);
@@ -310,9 +310,8 @@ StopBlinking(playerid) {
 
 // Remove object if there is an object at the |index| for the |playerid|
 DestroyDynamicBlinkerObject(playerid, index) {
-    if (g_blinkerObjects[playerid][index] > DynamicObject: INVALID_OBJECT_ID) {
+    if (IsValidDynamicObject(g_blinkerObjects[playerid][index])) {
         DestroyDynamicObject(g_blinkerObjects[playerid][index]);
-        g_blinkerObjects[playerid][index] = DynamicObject: INVALID_OBJECT_ID;
     }    
 }
 

--- a/pawn/Driver/Driver.pwn
+++ b/pawn/Driver/Driver.pwn
@@ -46,29 +46,6 @@ IsModelRemoteControlVehicle(modelId) {
     return false;
 }
 
-// Returns whether the given |modelId| is a boat.
-IsModelBoat(modelId) {
-    if(modelId == 460 || modelId == 476 || modelId == 511 || modelId == 512 || modelId == 513 ||
-        modelId == 519 || modelId == 520 || modelId == 553 || modelId == 577 || modelId == 592 ||
-        modelId == 593) {
-
-        return true;
-    }
-
-    return false;
-}
-
-// Returns whether the given |modelId| is a plane.
-IsModelPlane(modelId) {
-    if (modelId == 430 || modelId == 446 || modelId == 452 || modelId == 453 || modelId == 454 ||
-        modelId == 472 || modelId == 473 || modelId == 484 || modelId == 493 || modelId == 595) {
-
-        return true;
-    }
-
-    return false;
-}
-
 // Gets the ID of the player who is currently driving the given |vehicleId|.
 GetVehicleDriverID(vehicleId) {
     for (new playerId = 0; playerId < GetPlayerPoolSize(); ++playerId) {
@@ -260,23 +237,20 @@ public OnPlayerKeyStateChange(playerid, newkeys, oldkeys) {
                 AddVehicleComponent(vehicleId, 1010);
         }
 
-        new bool: rightBlinker = g_blinkerObjects[playerid][0] != 0;
-        new bool: leftBlinker = g_blinkerObjects[playerid][2] != 0;
-        // Vehicle keys (q): blinker left
-        if (PRESSED(VEHICLE_KEYS_BINDING_BLINKER_RIGHT) && 
-            (vehicleKeys & VEHICLE_KEYS_BLINKER_RIGHT)) {
+        new const bool: pressedBlinkerRight =
+            PRESSED(VEHICLE_KEYS_BINDING_BLINKER_RIGHT) && vehicleKeys & VEHICLE_KEYS_BLINKER_RIGHT;
+        new const bool: pressedBlinkerLeft = 
+            PRESSED(VEHICLE_KEYS_BINDING_BLINKER_LEFT) && vehicleKeys & VEHICLE_KEYS_BLINKER_LEFT;
 
-            rightBlinker = !rightBlinker;
+        if(pressedBlinkerRight || pressedBlinkerLeft) {
+            new const bool: blinkingOnRight = g_blinkerObjects[playerid][0] != 0;
+            new const bool: blinkingOnLeft = g_blinkerObjects[playerid][2] != 0;
+
+            new const bool: rightBlinker = pressedBlinkerRight ? !blinkingOnRight : blinkingOnRight;
+            new const bool: leftBlinker = pressedBlinkerLeft ? !blinkingOnLeft : blinkingOnLeft;
+
+            SetBinker(playerid, vehicleId, leftBlinker, rightBlinker);
         }
-
-        // Vehicle keys (e): blinker right
-        if (PRESSED(VEHICLE_KEYS_BINDING_BLINKER_LEFT) && 
-            (vehicleKeys & VEHICLE_KEYS_BLINKER_LEFT)) {
-
-            leftBlinker = !leftBlinker;
-        }
-
-        SetBlinker(playerid, vehicleId, leftBlinker, rightBlinker);
     }
 
     LegacyPlayerKeyStateChange(playerid, newkeys, oldkeys);
@@ -288,7 +262,7 @@ SetBlinker(playerid, vehicleId, bool:left, bool:right) {
     new const blinkerModel = 19294;
     new const modelId = GetVehicleModel(vehicleId);
 
-    if(IsModelBoat(modelId) || IsModelPlane(modelId)) {
+    if(VehicleModel(modelId)->isNitroInjectionAvailable()) {
         return;
     }
 
@@ -297,48 +271,48 @@ SetBlinker(playerid, vehicleId, bool:left, bool:right) {
 
     if (right) {
         if (g_blinkerObjects[playerid][0] == 0) {
-            g_blinkerObjects[playerid][0] = CreateObject(blinkerModel, 0, 0, 0, 0, 0, 0, 0);
+            g_blinkerObjects[playerid][0] = CreateDynamicObject(blinkerModel, 0, 0, 0, 0, 0, 0, 0);
             AttachObjectToVehicle(g_blinkerObjects[playerid][0], vehicleId, sizeX/2.23, sizeY/2.23, 
                 0.1, 0, 0, 0);
 
-            g_blinkerObjects[playerid][1] = CreateObject(blinkerModel, 0, 0, 0, 0, 0, 0, 0);
+            g_blinkerObjects[playerid][1] = CreateDynamicObject(blinkerModel, 0, 0, 0, 0, 0, 0, 0);
             AttachObjectToVehicle(g_blinkerObjects[playerid][1], vehicleId, sizeX/2.23, -sizeY/2.23, 
                 0.1, 0, 0, 0);
         }
     } else {
-        DestroyBlinkerObject(playerid, 0);
-        DestroyBlinkerObject(playerid, 1);
+        DestroyDynamicBlinkerObject(playerid, 0);
+        DestroyDynamicBlinkerObject(playerid, 1);
     }
 
     if (left) {
         if (g_blinkerObjects[playerid][2] == 0) {
-            g_blinkerObjects[playerid][2] = CreateObject(blinkerModel, 0, 0, 0, 0, 0, 0, 0);
+            g_blinkerObjects[playerid][2] = CreateDynamicObject(blinkerModel, 0, 0, 0, 0, 0, 0, 0);
             AttachObjectToVehicle(g_blinkerObjects[playerid][2], vehicleId, -sizeX/2.23, sizeY/2.23, 
                 0.1, 0, 0, 0);
 
-            g_blinkerObjects[playerid][3] = CreateObject(blinkerModel, 0, 0, 0, 0, 0, 0, 0);
+            g_blinkerObjects[playerid][3] = CreateDynamicObject(blinkerModel, 0, 0, 0, 0, 0, 0, 0);
             AttachObjectToVehicle(g_blinkerObjects[playerid][3], vehicleId, -sizeX/2.23, -sizeY/2.23, 
                 0.1, 0, 0, 0);
         }
     } else {
-        DestroyBlinkerObject(playerid, 2);
-        DestroyBlinkerObject(playerid, 3);
+        DestroyDynamicBlinkerObject(playerid, 2);
+        DestroyDynamicBlinkerObject(playerid, 3);
     }
 }
 
 // This resets the whole blinking status and removes the objects.
 forward StopBlinking(playerid);
 public StopBlinking(playerid) {
-    DestroyBlinkerObject(playerid, 0);
-    DestroyBlinkerObject(playerid, 1);
-    DestroyBlinkerObject(playerid, 2);
-    DestroyBlinkerObject(playerid, 3);
+    DestroyDynamicBlinkerObject(playerid, 0);
+    DestroyDynamicBlinkerObject(playerid, 1);
+    DestroyDynamicBlinkerObject(playerid, 2);
+    DestroyDynamicBlinkerObject(playerid, 3);
 }
 
 // Remove object if there is an object at the |index| for the |playerid|
-DestroyBlinkerObject(playerid, index) {
+DestroyDynamicBlinkerObject(playerid, index) {
     if (g_blinkerObjects[playerid][index] > 0) {
-        DestroyObject(g_blinkerObjects[playerid][index]);
+        DestroyDynamicObject(g_blinkerObjects[playerid][index]);
         g_blinkerObjects[playerid][index] = 0;
     }    
 }

--- a/pawn/Driver/Driver.pwn
+++ b/pawn/Driver/Driver.pwn
@@ -34,7 +34,7 @@ new g_sprayTagStartTime[MAX_PLAYERS];
 new g_vehicleKeysLastBoost[MAX_PLAYERS];
 
 // The four blinker objects for the player. 0/1 = RIGHT 2/3 = LEFT
-new g_blinkerObjects[MAX_PLAYERS][4];
+new DynamicObject: g_blinkerObjects[MAX_PLAYERS][4];
 
 // Returns whether the given |modelId| is a remote controllable vehicle.
 IsModelRemoteControlVehicle(modelId) {
@@ -243,13 +243,13 @@ public OnPlayerKeyStateChange(playerid, newkeys, oldkeys) {
             PRESSED(VEHICLE_KEYS_BINDING_BLINKER_LEFT) && vehicleKeys & VEHICLE_KEYS_BLINKER_LEFT;
 
         if(pressedBlinkerRight || pressedBlinkerLeft) {
-            new const bool: blinkingOnRight = g_blinkerObjects[playerid][0] != 0;
-            new const bool: blinkingOnLeft = g_blinkerObjects[playerid][2] != 0;
+            new const bool: blinkingOnRight = g_blinkerObjects[playerid][0] != DynamicObject: INVALID_OBJECT_ID;
+            new const bool: blinkingOnLeft = g_blinkerObjects[playerid][2] != DynamicObject: INVALID_OBJECT_ID;
 
             new const bool: rightBlinker = pressedBlinkerRight ? !blinkingOnRight : blinkingOnRight;
             new const bool: leftBlinker = pressedBlinkerLeft ? !blinkingOnLeft : blinkingOnLeft;
 
-            SetBinker(playerid, vehicleId, leftBlinker, rightBlinker);
+            SetBlinker(playerid, vehicleId, leftBlinker, rightBlinker);
         }
     }
 
@@ -270,13 +270,13 @@ SetBlinker(playerid, vehicleId, bool:left, bool:right) {
     GetVehicleModelInfo(modelId, VEHICLE_MODEL_INFO_SIZE, sizeX, sizeY, sizeZ);
 
     if (right) {
-        if (g_blinkerObjects[playerid][0] == 0) {
-            g_blinkerObjects[playerid][0] = CreateDynamicObject(blinkerModel, 0, 0, 0, 0, 0, 0, 0);
-            AttachObjectToVehicle(g_blinkerObjects[playerid][0], vehicleId, sizeX/2.23, sizeY/2.23, 
+        if (g_blinkerObjects[playerid][0] == DynamicObject: INVALID_OBJECT_ID) {
+            g_blinkerObjects[playerid][0] = CreateDynamicObject(blinkerModel, 0, 0, 0, 0, 0, 0);
+            AttachDynamicObjectToVehicle(g_blinkerObjects[playerid][0], vehicleId, sizeX/2.23, sizeY/2.23, 
                 0.1, 0, 0, 0);
 
-            g_blinkerObjects[playerid][1] = CreateDynamicObject(blinkerModel, 0, 0, 0, 0, 0, 0, 0);
-            AttachObjectToVehicle(g_blinkerObjects[playerid][1], vehicleId, sizeX/2.23, -sizeY/2.23, 
+            g_blinkerObjects[playerid][1] = CreateDynamicObject(blinkerModel, 0, 0, 0, 0, 0, 0);
+            AttachDynamicObjectToVehicle(g_blinkerObjects[playerid][1], vehicleId, sizeX/2.23, -sizeY/2.23, 
                 0.1, 0, 0, 0);
         }
     } else {
@@ -285,13 +285,13 @@ SetBlinker(playerid, vehicleId, bool:left, bool:right) {
     }
 
     if (left) {
-        if (g_blinkerObjects[playerid][2] == 0) {
-            g_blinkerObjects[playerid][2] = CreateDynamicObject(blinkerModel, 0, 0, 0, 0, 0, 0, 0);
-            AttachObjectToVehicle(g_blinkerObjects[playerid][2], vehicleId, -sizeX/2.23, sizeY/2.23, 
+        if (g_blinkerObjects[playerid][2] == DynamicObject: INVALID_OBJECT_ID) {
+            g_blinkerObjects[playerid][2] = CreateDynamicObject(blinkerModel, 0, 0, 0, 0, 0, 0);
+            AttachDynamicObjectToVehicle(g_blinkerObjects[playerid][2], vehicleId, -sizeX/2.23, sizeY/2.23, 
                 0.1, 0, 0, 0);
 
-            g_blinkerObjects[playerid][3] = CreateDynamicObject(blinkerModel, 0, 0, 0, 0, 0, 0, 0);
-            AttachObjectToVehicle(g_blinkerObjects[playerid][3], vehicleId, -sizeX/2.23, -sizeY/2.23, 
+            g_blinkerObjects[playerid][3] = CreateDynamicObject(blinkerModel, 0, 0, 0, 0, 0, 0);
+            AttachDynamicObjectToVehicle(g_blinkerObjects[playerid][3], vehicleId, -sizeX/2.23, -sizeY/2.23, 
                 0.1, 0, 0, 0);
         }
     } else {
@@ -311,9 +311,9 @@ public StopBlinking(playerid) {
 
 // Remove object if there is an object at the |index| for the |playerid|
 DestroyDynamicBlinkerObject(playerid, index) {
-    if (g_blinkerObjects[playerid][index] > 0) {
+    if (g_blinkerObjects[playerid][index] > DynamicObject: INVALID_OBJECT_ID) {
         DestroyDynamicObject(g_blinkerObjects[playerid][index]);
-        g_blinkerObjects[playerid][index] = 0;
+        g_blinkerObjects[playerid][index] = DynamicObject: INVALID_OBJECT_ID;
     }    
 }
 

--- a/pawn/Driver/Driver.pwn
+++ b/pawn/Driver/Driver.pwn
@@ -301,8 +301,7 @@ SetBlinker(playerid, vehicleId, bool:left, bool:right) {
 }
 
 // This resets the whole blinking status and removes the objects.
-forward StopBlinking(playerid);
-public StopBlinking(playerid) {
+StopBlinking(playerid) {
     DestroyDynamicBlinkerObject(playerid, 0);
     DestroyDynamicBlinkerObject(playerid, 1);
     DestroyDynamicBlinkerObject(playerid, 2);

--- a/pawn/Entities/Players/PlayerEvents.pwn
+++ b/pawn/Entities/Players/PlayerEvents.pwn
@@ -191,6 +191,5 @@ class PlayerEvents <playerId (MAX_PLAYERS)> {
  * implementation will reside. The cost of introducing an additional call here is negligible.
  */
 public OnIncomingConnection(playerid, ip_address[], port) { PlayerEvents(playerid)->onIncomingConnection(ip_address, port); return 1; }
-public OnPlayerDisconnect(playerid, reason) { return PlayerEvents(playerid)->onPlayerDisconnect(reason); }
 public OnPlayerClickMap(playerid, Float:fX, Float:fY, Float:fZ) { PlayerEvents(playerid)->onPlayerClickMap(fX, fY, fZ); return 1; }
 public OnPlayerClickTextDraw(playerid, Text:clickedid) { return PlayerEvents(playerid)->onPlayerClickTextDraw(clickedid); }

--- a/pawn/Entities/Players/PlayerSyncedData.pwn
+++ b/pawn/Entities/Players/PlayerSyncedData.pwn
@@ -114,7 +114,7 @@ class PlayerSyncedData <playerId (MAX_PLAYERS)> {
 
             case VEHICLE_KEYS: {
                 m_vehicleKeys = intValue;
-                if(m_vehicleKeys | VEHICLE_KEYS_BLINKER_RIGHT) {
+                if((m_vehicleKeys & VEHICLE_KEYS_BLINKER_RIGHT) == 0) {
                     // Blinking enable/disable always goes together.
                     // If right is disable blinking is disabled thus stop the blinking.
                     StopBlinking(playerId);

--- a/pawn/Entities/Players/PlayerSyncedData.pwn
+++ b/pawn/Entities/Players/PlayerSyncedData.pwn
@@ -112,8 +112,14 @@ class PlayerSyncedData <playerId (MAX_PLAYERS)> {
             case PREFERRED_RADIO_CHANNEL:
                 format(m_preferredRadioChannel, sizeof(m_preferredRadioChannel), "%s", stringValue);
 
-            case VEHICLE_KEYS:
+            case VEHICLE_KEYS: {
                 m_vehicleKeys = intValue;
+                if(m_vehicleKeys | VEHICLE_KEYS_BLINKER_RIGHT) {
+                    // Blinking enable/disable always goes together.
+                    // If right is disable blinking is disabled thus stop the blinking.
+                    StopBlinking(playerId);
+                }
+            }
         }
 
         #pragma unused floatValue

--- a/pawn/Interface/Server.pwn
+++ b/pawn/Interface/Server.pwn
@@ -37,7 +37,7 @@ native ReportPlayerTeleport(playerId, timeLimited);
 #define VEHICLE_KEYS_JUMP 16
 #define VEHICLE_KEYS_NOS 32
 #define VEHICLE_KEYS_BLINKER_RIGHT 64
-#define VEHICLE_KEYS_BLINKER_LEFT 256
+#define VEHICLE_KEYS_BLINKER_LEFT 128
 
 native IsPersistentVehicle(vehicleId);
 native IsCommunicationMuted();

--- a/pawn/Interface/Server.pwn
+++ b/pawn/Interface/Server.pwn
@@ -36,6 +36,8 @@ native ReportPlayerTeleport(playerId, timeLimited);
 #define VEHICLE_KEYS_FLIP 8
 #define VEHICLE_KEYS_JUMP 16
 #define VEHICLE_KEYS_NOS 32
+#define VEHICLE_KEYS_BLINKER_RIGHT 64
+#define VEHICLE_KEYS_BLINKER_LEFT 256
 
 native IsPersistentVehicle(vehicleId);
 native IsCommunicationMuted();


### PR DESCRIPTION
Thank you for making a contribution to [Las Venturas Playground](https://sa-mp.nl/)!

Please take a moment to fill in the questions in this template, to make it easier for our developers
to understand what you're doing.

## What is being changed?
_Allow people to use blinkers using numpad 4 and 6 after the /indicators command has enabled the player to._

## Why is this being changed?
_Because, why not. I was chasing @JTrolin around LS and was always too late realizing he'd make a turn._

## How are you making the change?
  [X] I have a working check-out of Las Venturas Playground.
  [] I have included tests for any changed JavaScript code. (Too much coupling to game. Tested IG instead)
  [X] I have tested this change myself on my local server.
