### PR TITLE
Set vault and door object to INVALID_OBJECT_ID after destroying

### DIFF
--- a/pawn/Resources/Minigames/Core/Robbery.pwn
+++ b/pawn/Resources/Minigames/Core/Robbery.pwn
@@ -455,8 +455,14 @@ CRobbery__DestroyAll()
     CRobbery__UpdateTDs();
 
 
-    if(IsValidDynamicObject(vaultObject)) DestroyDynamicObject(vaultObject);
-    DestroyDynamicObject(doorObject);
+    if(IsValidDynamicObject(vaultObject)) { 
+        DestroyDynamicObject(vaultObject);
+        vaultObject = DynamicObject: INVALID_OBJECT_ID;
+    }
+    if(IsValidDynamicObject(doorObject)) { 
+        DestroyDynamicObject(doorObject);
+        doorObject = DynamicObject: INVALID_OBJECT_ID;
+    }
 
     for (new i = 0; i <= PlayerManager->highestPlayerId(); i++) {
         if(CRobbery__GetPlayerStatus(i) == ROBSTATUS_PLAYING) {


### PR DESCRIPTION
Thank you for making a contribution to [Las Venturas Playground](https://sa-mp.nl/)!

Please take a moment to fill in the questions in this template, to make it easier for our developers
to understand what you're doing.

## What is being changed?
_Not reseting it might cause it to destroy JS objects what would bug the server._

## How are you making the change?
  [ x ] I have a working check-out of Las Venturas Playground.
