### PR TITLE
Add two deathmatch zones for Lag Shot fights

### DIFF
--- a/data/death_match_locations.json
+++ b/data/death_match_locations.json
@@ -1,41 +1,13 @@
 [
     {
         "id": 1,
-        "name": "LV RW FightClub (skin hit)",
+        "name": "LV RW FightClub",
         "weather": 10,
         "time": 12,
 
         "player_health" : 100,
         "player_armour" : 100,
 
-        "weapons" : [
-            { "weapon_id" : 26, "ammo": 1337 },
-            { "weapon_id" : 28, "ammo": 80085 }
-        ],
-    
-        "interior_id": 0,
-        "spawn_positions": [
-            { "position": [ 2096.18, 2186.78, 10.82 ], "rotation": 136.84 },
-            { "position": [ 2068.54, 2157.53, 10.82 ], "rotation": 311.35 },
-            { "position": [ 2068.54, 2186.78, 10.82 ], "rotation": 222.67 },
-            { "position": [ 2096.18, 2157.53, 10.82 ], "rotation":  33.75 },
-            { "position": [ 2068.54, 2172.16, 10.82 ], "rotation": 270.00 },
-            { "position": [ 2082.36, 2186.78, 10.82 ], "rotation": 180.00 },
-            { "position": [ 2082.36, 2157.53, 10.82 ], "rotation":   0.00 },
-            { "position": [ 2096.18, 2172.16, 10.82 ], "rotation":  90.00 }
-        ],
-        "boundaries": [ 2110.8208, 2055.1360, 2200.4045, 2144.6980 ]
-    },
-    {
-        "id": 6,
-        "name": "LV RW FightClub (lag shot)",
-        "weather": 10,
-        "time": 12,
-
-        "player_health" : 100,
-        "player_armour" : 100,
-
-        "lag_shot": true,
         "weapons" : [
             { "weapon_id" : 26, "ammo": 1337 },
             { "weapon_id" : 28, "ammo": 80085 }
@@ -110,33 +82,6 @@
         "boundaries": [ 1392, 1304, 2193, 2106 ]
     },
     {
-        "id": 7,
-        "name": "Baseball field RW (lag shot)",
-        "weather": 10,
-        "time": 12,
-
-        "player_health" : 100,
-        "player_armour" : 100,
-
-        "lag_shot": true,
-        "weapons" : [
-            { "weapon_id" : 26, "ammo": 1337 },
-            { "weapon_id" : 28, "ammo": 80085 }
-        ],
-    
-        "interior_id": 0,
-        "spawn_positions": [
-            { "position": [ 1305.4459, 2107.5073, 11.0156 ], "rotation": 326 },
-            { "position": [ 1306.3177, 2154.8152, 11.0234 ], "rotation": 274 },
-            { "position": [ 1305.3868, 2191.5332, 11.0234 ], "rotation": 214 },
-            { "position": [ 1390.2855, 2191.9712, 11.0234 ], "rotation": 131 },
-            { "position": [ 1390.3672, 2107.3330, 11.0156 ], "rotation": 41 },
-            { "position": [ 1349.7422, 2107.3530, 11.0156 ], "rotation": 358 },
-            { "position": [ 1372, 2149.5, 11.02 ], "rotation": 0 }
-        ],
-        "boundaries": [ 1392, 1304, 2193, 2106 ]
-    },
-    {
         "id": 4,
         "name": "Baseball field Rockets",
         "weather": 10,
@@ -163,13 +108,79 @@
     },
     {
         "id": 5,
-        "name": "SF military RW",
+        "name": "SF military RW (skin hit)",
         "weather": 10,
         "time": 10,
 
         "player_health" : 100,
         "player_armour" : 100,
 
+        "weapons" : [
+            { "weapon_id" : 26, "ammo": 1337 },
+            { "weapon_id" : 28, "ammo": 80085 }
+        ],
+    
+        "interior_id": 0,
+        "spawn_positions": [
+            { "position": [ -1471, 412, 32 ], "rotation": 0 },
+            { "position": [ -1479, 413, 32 ], "rotation": 0 },
+            { "position": [ -1404, 370, 32 ], "rotation": 0 },
+            { "position": [ -1385, 375, 32 ], "rotation": 0 },
+            { "position": [ -1428, 355, 32 ], "rotation": 0 },
+            { "position": [ -1454, 369, 32 ], "rotation": 0 },
+            { "position": [ -1405, 359, 32 ], "rotation": 0 },
+            { "position": [ -1400, 386, 32 ], "rotation": 0 },
+            { "position": [ -1467, 399, 32 ], "rotation": 0 },
+            { "position": [ -1430, 394, 32 ], "rotation": 0 },
+            { "position": [ -1431, 371, 32 ], "rotation": 0 },
+            { "position": [ -1445, 388, 32 ], "rotation": 0 },
+            { "position": [ -1429, 417, 32 ], "rotation": 0 },
+            { "position": [ -1448, 345, 32 ], "rotation": 0 },
+            { "position": [ -1453, 393, 32 ], "rotation": 0 },
+            { "position": [ -1405, 413, 32 ], "rotation": 0 },
+            { "position": [ -1443, 347, 32 ], "rotation": 0 },
+            { "position": [ -1453, 365, 32 ], "rotation": 0 },
+            { "position": [ -1453, 389, 32 ], "rotation": 0 }
+        ],
+        "boundaries": [ -1343.2637, -1485.9154, 447.1273, 334.7642 ]
+    },
+    {
+        "id": 6,
+        "name": "Baseball field RW (lag shot)",
+        "weather": 10,
+        "time": 12,
+
+        "player_health" : 100,
+        "player_armour" : 100,
+
+        "lag_shot": true,
+        "weapons" : [
+            { "weapon_id" : 26, "ammo": 1337 },
+            { "weapon_id" : 28, "ammo": 80085 }
+        ],
+    
+        "interior_id": 0,
+        "spawn_positions": [
+            { "position": [ 1305.4459, 2107.5073, 11.0156 ], "rotation": 326 },
+            { "position": [ 1306.3177, 2154.8152, 11.0234 ], "rotation": 274 },
+            { "position": [ 1305.3868, 2191.5332, 11.0234 ], "rotation": 214 },
+            { "position": [ 1390.2855, 2191.9712, 11.0234 ], "rotation": 131 },
+            { "position": [ 1390.3672, 2107.3330, 11.0156 ], "rotation": 41 },
+            { "position": [ 1349.7422, 2107.3530, 11.0156 ], "rotation": 358 },
+            { "position": [ 1372, 2149.5, 11.02 ], "rotation": 0 }
+        ],
+        "boundaries": [ 1392, 1304, 2193, 2106 ]
+    },
+    {
+        "id": 7,
+        "name": "SF military RW (lag shot)",
+        "weather": 10,
+        "time": 10,
+
+        "player_health" : 100,
+        "player_armour" : 100,
+
+        "lag_shot": true,
         "weapons" : [
             { "weapon_id" : 26, "ammo": 1337 },
             { "weapon_id" : 28, "ammo": 80085 }

--- a/data/death_match_locations.json
+++ b/data/death_match_locations.json
@@ -1,13 +1,41 @@
 [
     {
         "id": 1,
-        "name": "LV RW FightClub",
+        "name": "LV RW FightClub (skin hit)",
         "weather": 10,
         "time": 12,
 
         "player_health" : 100,
         "player_armour" : 100,
 
+        "weapons" : [
+            { "weapon_id" : 26, "ammo": 1337 },
+            { "weapon_id" : 28, "ammo": 80085 }
+        ],
+    
+        "interior_id": 0,
+        "spawn_positions": [
+            { "position": [ 2096.18, 2186.78, 10.82 ], "rotation": 136.84 },
+            { "position": [ 2068.54, 2157.53, 10.82 ], "rotation": 311.35 },
+            { "position": [ 2068.54, 2186.78, 10.82 ], "rotation": 222.67 },
+            { "position": [ 2096.18, 2157.53, 10.82 ], "rotation":  33.75 },
+            { "position": [ 2068.54, 2172.16, 10.82 ], "rotation": 270.00 },
+            { "position": [ 2082.36, 2186.78, 10.82 ], "rotation": 180.00 },
+            { "position": [ 2082.36, 2157.53, 10.82 ], "rotation":   0.00 },
+            { "position": [ 2096.18, 2172.16, 10.82 ], "rotation":  90.00 }
+        ],
+        "boundaries": [ 2110.8208, 2055.1360, 2200.4045, 2144.6980 ]
+    },
+    {
+        "id": 6,
+        "name": "LV RW FightClub (lag shot)",
+        "weather": 10,
+        "time": 12,
+
+        "player_health" : 100,
+        "player_armour" : 100,
+
+        "lag_shot": true,
         "weapons" : [
             { "weapon_id" : 26, "ammo": 1337 },
             { "weapon_id" : 28, "ammo": 80085 }
@@ -57,13 +85,40 @@
     },
     {
         "id": 3,
-        "name": "Baseball field RW",
+        "name": "Baseball field RW (skin hit)",
         "weather": 10,
         "time": 12,
 
         "player_health" : 100,
         "player_armour" : 100,
 
+        "weapons" : [
+            { "weapon_id" : 26, "ammo": 1337 },
+            { "weapon_id" : 28, "ammo": 80085 }
+        ],
+    
+        "interior_id": 0,
+        "spawn_positions": [
+            { "position": [ 1305.4459, 2107.5073, 11.0156 ], "rotation": 326 },
+            { "position": [ 1306.3177, 2154.8152, 11.0234 ], "rotation": 274 },
+            { "position": [ 1305.3868, 2191.5332, 11.0234 ], "rotation": 214 },
+            { "position": [ 1390.2855, 2191.9712, 11.0234 ], "rotation": 131 },
+            { "position": [ 1390.3672, 2107.3330, 11.0156 ], "rotation": 41 },
+            { "position": [ 1349.7422, 2107.3530, 11.0156 ], "rotation": 358 },
+            { "position": [ 1372, 2149.5, 11.02 ], "rotation": 0 }
+        ],
+        "boundaries": [ 1392, 1304, 2193, 2106 ]
+    },
+    {
+        "id": 7,
+        "name": "Baseball field RW (lag shot)",
+        "weather": 10,
+        "time": 12,
+
+        "player_health" : 100,
+        "player_armour" : 100,
+
+        "lag_shot": true,
         "weapons" : [
             { "weapon_id" : 26, "ammo": 1337 },
             { "weapon_id" : 28, "ammo": 80085 }
@@ -108,7 +163,7 @@
     },
     {
         "id": 5,
-        "name": "SF milatary RW",
+        "name": "SF military RW",
         "weather": 10,
         "time": 10,
 
@@ -123,24 +178,24 @@
         "interior_id": 0,
         "spawn_positions": [
             { "position": [ -1471, 412, 32 ], "rotation": 0 },
-			{ "position": [ -1479, 413, 32 ], "rotation": 0 },
-			{ "position": [ -1404, 370, 32 ], "rotation": 0 },
-			{ "position": [ -1385, 375, 32 ], "rotation": 0 },
-			{ "position": [ -1428, 355, 32 ], "rotation": 0 },
-			{ "position": [ -1454, 369, 32 ], "rotation": 0 },
-			{ "position": [ -1405, 359, 32 ], "rotation": 0 },
-			{ "position": [ -1400, 386, 32 ], "rotation": 0 },
-			{ "position": [ -1467, 399, 32 ], "rotation": 0 },
-			{ "position": [ -1430, 394, 32 ], "rotation": 0 },
-			{ "position": [ -1431, 371, 32 ], "rotation": 0 },
-			{ "position": [ -1445, 388, 32 ], "rotation": 0 },
-			{ "position": [ -1429, 417, 32 ], "rotation": 0 },
-			{ "position": [ -1448, 345, 32 ], "rotation": 0 },
-			{ "position": [ -1453, 393, 32 ], "rotation": 0 },
-			{ "position": [ -1405, 413, 32 ], "rotation": 0 },
-			{ "position": [ -1443, 347, 32 ], "rotation": 0 },
-			{ "position": [ -1453, 365, 32 ], "rotation": 0 },
-			{ "position": [ -1453, 389, 32 ], "rotation": 0 }
+            { "position": [ -1479, 413, 32 ], "rotation": 0 },
+            { "position": [ -1404, 370, 32 ], "rotation": 0 },
+            { "position": [ -1385, 375, 32 ], "rotation": 0 },
+            { "position": [ -1428, 355, 32 ], "rotation": 0 },
+            { "position": [ -1454, 369, 32 ], "rotation": 0 },
+            { "position": [ -1405, 359, 32 ], "rotation": 0 },
+            { "position": [ -1400, 386, 32 ], "rotation": 0 },
+            { "position": [ -1467, 399, 32 ], "rotation": 0 },
+            { "position": [ -1430, 394, 32 ], "rotation": 0 },
+            { "position": [ -1431, 371, 32 ], "rotation": 0 },
+            { "position": [ -1445, 388, 32 ], "rotation": 0 },
+            { "position": [ -1429, 417, 32 ], "rotation": 0 },
+            { "position": [ -1448, 345, 32 ], "rotation": 0 },
+            { "position": [ -1453, 393, 32 ], "rotation": 0 },
+            { "position": [ -1405, 413, 32 ], "rotation": 0 },
+            { "position": [ -1443, 347, 32 ], "rotation": 0 },
+            { "position": [ -1453, 365, 32 ], "rotation": 0 },
+            { "position": [ -1453, 389, 32 ], "rotation": 0 }
         ],
         "boundaries": [ -1343.2637, -1485.9154, 447.1273, 334.7642 ]
     }

--- a/javascript/features/death_match/death_match_location.js
+++ b/javascript/features/death_match/death_match_location.js
@@ -79,7 +79,7 @@ export class DeathMatchLocation {
         this.playerHealth_ = locationInfo.player_health ?? 100;
         this.playerArmour_ = locationInfo.player_armour ?? 0;
 
-        this.lagShot_ = locationInfo.lagShot ?? false;
+        this.lagShot_ = locationInfo.lag_shot ?? false;
         this.weapons_ = new Set();
 
         locationInfo.weapons.forEach(weaponInfo => {

--- a/javascript/features/death_match/death_match_location.test.js
+++ b/javascript/features/death_match/death_match_location.test.js
@@ -19,7 +19,7 @@ describe('DeathMatchLocation', (it) => {
         const location = DeathMatchLocation.getById(1);
 
         assert.isNotNull(location);
-        assert.equal(location.name, 'LV RW FightClub (skin hit)');
+        assert.equal(location.name, 'LV RW FightClub');
 
         assert.throws(() => DeathMatchLocation.getById(null));
         assert.throws(() => DeathMatchLocation.getById(0));

--- a/javascript/features/death_match/death_match_location.test.js
+++ b/javascript/features/death_match/death_match_location.test.js
@@ -19,7 +19,7 @@ describe('DeathMatchLocation', (it) => {
         const location = DeathMatchLocation.getById(1);
 
         assert.isNotNull(location);
-        assert.equal(location.name, 'LV RW FightClub');
+        assert.equal(location.name, 'LV RW FightClub (skin hit)');
 
         assert.throws(() => DeathMatchLocation.getById(null));
         assert.throws(() => DeathMatchLocation.getById(0));

--- a/javascript/features/death_match/death_match_manager.js
+++ b/javascript/features/death_match/death_match_manager.js
@@ -55,7 +55,7 @@ export class DeathMatchManger {
         const targetLagCompensationMode = zoneInfo.lagShot ? 0 : 2;
 
         if (player.syncedData.lagCompensationMode !== targetLagCompensationMode)
-            player.syncedData.lagCompensationMode = 0;  // this will respawn the |player|
+            player.syncedData.lagCompensationMode = targetLagCompensationMode;
         else
             this.spawnPlayer(player, zone);
 

--- a/javascript/features/death_match/death_match_manager.js
+++ b/javascript/features/death_match/death_match_manager.js
@@ -56,8 +56,8 @@ export class DeathMatchManger {
 
         if (player.syncedData.lagCompensationMode !== targetLagCompensationMode)
             player.syncedData.lagCompensationMode = targetLagCompensationMode;
-        else
-            this.spawnPlayer(player, zone);
+        
+        this.spawnPlayer(player, zone);
 
         player.sendMessage(Message.DEATH_MATCH_INSTRUCTION_LEAVE);
         player.sendMessage(Message.DEATH_MATCH_INSTRUCTION_STATS);

--- a/javascript/features/death_match/death_match_manager.test.js
+++ b/javascript/features/death_match/death_match_manager.test.js
@@ -204,4 +204,30 @@ describe('DeathMatchManager', (it, beforeEach) => {
         assert.equal(russell.health, 100);
         assert.equal(russell.armour, 100);
     });
+
+    it('should enable lag compensation mode to be toggled per zone', async (assert) => {
+        const gunther = server.playerManager.getById(0 /* Gunther */);
+
+        assert.equal(gunther.syncedData.lagCompensationMode, 2);
+
+        // (1) Teleport to a Lag Shot DM zone.
+        manager.goToDmZone(gunther, /* Baseball field RW (lag shot)= */ 7);
+        assert.equal(gunther.syncedData.lagCompensationMode, 0);
+
+        // (2) Leave it.
+        manager.leave(gunther);
+        assert.equal(gunther.syncedData.lagCompensationMode, 2);
+
+        // (3) Teleport to a Skin Hit DM zone.
+        manager.goToDmZone(gunther, /* Baseball field RW (skin hit)= */ 3);
+        assert.equal(gunther.syncedData.lagCompensationMode, 2);
+
+        // (4) Teleport directly to a Lag Shot DM zone.
+        manager.goToDmZone(gunther, /* Baseball field RW (lag shot)= */ 7);
+        assert.equal(gunther.syncedData.lagCompensationMode, 0);
+
+        // (5) Leave it.
+        manager.leave(gunther);
+        assert.equal(gunther.syncedData.lagCompensationMode, 2);
+    });
 });


### PR DESCRIPTION
Thank you for making a contribution to [Las Venturas Playground](https://sa-mp.nl/)!

Please take a moment to fill in the questions in this template, to make it easier for our developers
to understand what you're doing.

## What is being changed?
Branch the two most popular `/deathmatch` areas, Fight Club and the Baseball field, in skin hit and lag shot variants. The new zones have IDs `6` and `7`.

## Why is this being changed?
To enable players to have fights with their preferred lag compensation mode.

## How are you making the change?
  [X] I have a working check-out of Las Venturas Playground.
  [X] I have included tests for any changed JavaScript code.
  [X] I have tested this change myself on my local server.
