### PR TITLE
Making /weapons available to all players

### DIFF
--- a/pawn/Entities/Weapons/WeaponUtilities.pwn
+++ b/pawn/Entities/Weapons/WeaponUtilities.pwn
@@ -91,9 +91,7 @@ class WeaponUtilities {
      */
     @command("weapons")
     public onWeaponsCommand(playerId, params[]) {
-        if (Player(playerId)->isAdministrator() == false)
-            return 0;
-
+        
         new dialogCaption[32], dialogMessage[900], weaponName[32];
         format(dialogCaption, sizeof(dialogCaption), "Weapons and Ids");
 


### PR DESCRIPTION
Thank you for making a contribution to [Las Venturas Playground](https://sa-mp.nl/)!

Please take a moment to fill in the questions in this template, to make it easier for our developers
to understand what you're doing.

## What is being changed?
Removing restriction on /weapons
(Now all players can use this command)

## Why is this being changed?
Players need weapons id in order to buy spawnweapons ( /my spawnweapons )

## How are you making the change?
 I have tested this change myself on my local server.
