### PR TITLE
Preventing temp admins to use /account [player]

### DIFF
--- a/javascript/features/account/account_commands.js
+++ b/javascript/features/account/account_commands.js
@@ -44,7 +44,7 @@ export class AccountCommands {
             .description(`Enables you to manage your LVP account.`)
             .sub(CommandBuilder.kTypePlayer, 'target')
                 .description(`Enables administrators to manage anyone's account.`)
-                .restrict(Player.LEVEL_ADMINISTRATOR)
+                .restrict(Player.LEVEL_ADMINISTRATOR, /* restrictTemporary= */ true)
                 .build(AccountCommands.prototype.onAccountCommand.bind(this))
             .build(AccountCommands.prototype.onAccountCommand.bind(this));
 


### PR DESCRIPTION
Thank you for making a contribution to [Las Venturas Playground](https://sa-mp.nl/)!

Please take a moment to fill in the questions in this template, to make it easier for our developers
to understand what you're doing.

## What is being changed?
account_commands.js

## Why is this being changed?
Preventing temp admins to see other players /account 

## How are you making the change?
  [  ] I have a working check-out of Las Venturas Playground.
  [  ] I have included tests for any changed JavaScript code.
  [ Done ] I have tested this change myself on my local server.
