### PR TITLE
Prevent temp admins to do /tempfix on non admin players

### DIFF
--- a/javascript/features/playground/playground_commands.js
+++ b/javascript/features/playground/playground_commands.js
@@ -41,7 +41,7 @@ export class PlaygroundCommands {
         // they have been granted temporary administrator rights.
         server.commandManager.buildCommand('tempfix')
             .description('Grants temporary rights to a particular player.')
-            .restrict(Player.LEVEL_ADMINISTRATOR)
+            .restrict(Player.LEVEL_ADMINISTRATOR, /* restrictTemporary= */ true)
             .parameters([ { name: 'player', type: CommandBuilder.kTypePlayer } ])
             .build(PlaygroundCommands.prototype.onTempFixCommand.bind(this));
 


### PR DESCRIPTION
Thank you for making a contribution to [Las Venturas Playground](https://sa-mp.nl/)!

Please take a moment to fill in the questions in this template, to make it easier for our developers
to understand what you're doing.

## What is being changed?
playground_commands.js

## Why is this being changed?
Temp admins can /tempfix non admin players , which give them some admin cmds like /jetpack /announce /rampcar /account [player]  etc.

## How are you making the change?
  [ ] I have a working check-out of Las Venturas Playground.
  [ ] I have included tests for any changed JavaScript code.
  [ Done ] I have tested this change myself on my local server.
