### PR TITLE
Addition and Modification in OnPlayerCommandText.pwn

### DIFF
--- a/pawn/Resources/Callbacks/OnPlayer/OnPlayerCommandText.pwn
+++ b/pawn/Resources/Callbacks/OnPlayer/OnPlayerCommandText.pwn
@@ -863,10 +863,7 @@ public OnPlayerCommandText(playerid, cmdtext[]) {
             if (!Player(player)->isAdministrator()) continue;
             if (IsPlayerAdmin(player)) continue;
 
-            
-    
-            if (Player(player)->isDeveloper())
-                format(playerLevel, sizeof(playerLevel), "Developer");      
+        
             if (Player(player)->isAdministrator() && !Player(player)->isManagement())
                 format(playerLevel, sizeof(playerLevel), "Administrator");
             else if (Player(player)->isManagement())
@@ -876,8 +873,7 @@ public OnPlayerCommandText(playerid, cmdtext[]) {
             format(message, sizeof(message), " %s (Id:%d) - {FF8E02}%s", Player(player)->nicknameString(),
                 player, playerLevel);
 
-            // If the user was temp'd, show admins who temp'd the player.
-                 
+            // If the user was temp'd, show admins who temp'd the player. 
                 if (Player(playerid)->isAdministrator()) 
                     {
                   if (tempLevel[player] == 1 || tempLevel[player] == 2) 
@@ -922,24 +918,24 @@ public OnPlayerCommandText(playerid, cmdtext[]) {
         SendClientMessage(playerid, COLOR_ORANGE, "List of VIPs online in Las Venturas Playground");
 
         new message[128], vipCount = 0, playerLevel[30];
-        for (new player = 0; player <= PlayerManager->highestPlayerId(); player++) {
-            if (!Player(player)->isConnected()) continue;
-            if (!Player(player)->isVip()) continue;
-            if (IsPlayerAdmin(player)) continue;
+        for (new playerId = 0; playerId <= PlayerManager->highestPlayerId(); playerId++) {
+            if (!Player(playerId)->isConnected()) continue;
+            if (!Player(playerId)->isVip()) continue;
+            if (IsPlayerAdmin(playerId)) continue;
 
             
-            if (Player(player)->isVip())
+            if (Player(playerId)->isVip())
                 format(playerLevel, sizeof(playerLevel), "VIP");
-            if (Player(player)->isDeveloper())
-                format(playerLevel, sizeof(playerLevel), "VIP / Developer");          
-            if (Player(player)->isAdministrator() && !Player(player)->isManagement())
+            if (Player(playerId)->isDeveloper())
+                format(playerLevel, sizeof(playerLevel), "Developer");          
+            if (Player(playerId)->isAdministrator() && !Player(player)->isManagement())
                 format(playerLevel, sizeof(playerLevel), "VIP / Administrator");  
-            if (Player(player)->isManagement())
+            if (Player(playerId)->isManagement())
                 format(playerLevel, sizeof(playerLevel), "Manager");    
             
             // Format the message for any general player.
             format(message, sizeof(message), " %s (Id:%d) - {FFFF00}%s", Player(player)->nicknameString(),
-                player, playerLevel);
+                playerId, playerLevel);
             
             
             

--- a/pawn/Resources/Callbacks/OnPlayer/OnPlayerCommandText.pwn
+++ b/pawn/Resources/Callbacks/OnPlayer/OnPlayerCommandText.pwn
@@ -868,7 +868,7 @@ public OnPlayerCommandText(playerid, cmdtext[]) {
             if (Player(player)->isDeveloper())
                 format(playerLevel, sizeof(playerLevel), "Developer");      
             if (Player(player)->isAdministrator() && !Player(player)->isManagement())
-                format(playerLevel, sizeof(playerLevel), "Administrator");  
+                format(playerLevel, sizeof(playerLevel), "Administrator");
             else if (Player(player)->isManagement())
                 format(playerLevel, sizeof(playerLevel), "Manager");
 
@@ -877,8 +877,8 @@ public OnPlayerCommandText(playerid, cmdtext[]) {
                 player, playerLevel);
 
             // If the user was temp'd, show admins who temp'd the player.
-            {     
-                if (Player(playerid)->isAdministrator() && Player(playerid)->isManagement()) 
+                 
+                if (Player(playerid)->isAdministrator()) 
                     {
                   if (tempLevel[player] == 1 || tempLevel[player] == 2) 
                     format(message, sizeof(message), " %s {CCCCCC}(temp'd by %s){FFFFFF} (Id:%d) - {FF8E02}%s",
@@ -886,10 +886,10 @@ public OnPlayerCommandText(playerid, cmdtext[]) {
                     }
                 else {
                     if (tempLevel[player] == 2) 
-                    format(message, sizeof(message), " %s (Id:%d) - {FF8E02}Temp.Admin",
+                    format(message, sizeof(message), " %s (Id:%d) - {FF8E02}Temporary Administrator",
                         Player(player)->nicknameString(), player);
                      }    
-            }
+            
 
             // If a player is undercover, show this to other admins.
             if (UndercoverAdministrator(player)->isUndercoverAdministrator()) {

--- a/pawn/Resources/Callbacks/OnPlayer/OnPlayerCommandText.pwn
+++ b/pawn/Resources/Callbacks/OnPlayer/OnPlayerCommandText.pwn
@@ -863,8 +863,12 @@ public OnPlayerCommandText(playerid, cmdtext[]) {
             if (!Player(player)->isAdministrator()) continue;
             if (IsPlayerAdmin(player)) continue;
 
+            
+    
+            if (Player(player)->isDeveloper())
+                format(playerLevel, sizeof(playerLevel), "Developer");      
             if (Player(player)->isAdministrator() && !Player(player)->isManagement())
-                format(playerLevel, sizeof(playerLevel), "Administrator");
+                format(playerLevel, sizeof(playerLevel), "Administrator");  
             else if (Player(player)->isManagement())
                 format(playerLevel, sizeof(playerLevel), "Manager");
 
@@ -873,10 +877,18 @@ public OnPlayerCommandText(playerid, cmdtext[]) {
                 player, playerLevel);
 
             // If the user was temp'd, show admins who temp'd the player.
-            if (tempLevel[player] == 1 || tempLevel[player] == 2) {
-                if (Player(playerid)->isAdministrator())
+            {     
+                if (Player(playerid)->isAdministrator() && Player(playerid)->isManagement()) 
+                    {
+                  if (tempLevel[player] == 1 || tempLevel[player] == 2) 
                     format(message, sizeof(message), " %s {CCCCCC}(temp'd by %s){FFFFFF} (Id:%d) - {FF8E02}%s",
-                        Player(player)->nicknameString(), UserTemped[player], player, playerLevel);
+                        Player(player)->nicknameString(), UserTemped[player], player, playerLevel); 
+                    }
+                else {
+                    if (tempLevel[player] == 2) 
+                    format(message, sizeof(message), " %s (Id:%d) - {FF8E02}Temp.Admin",
+                        Player(player)->nicknameString(), player);
+                     }    
             }
 
             // If a player is undercover, show this to other admins.
@@ -905,6 +917,44 @@ public OnPlayerCommandText(playerid, cmdtext[]) {
 
         return 1;
     }
+
+    if (strcmp(cmd, "/vips", true) == 0) {
+        SendClientMessage(playerid, COLOR_ORANGE, "List of VIPs online in Las Venturas Playground");
+
+        new message[128], vipCount = 0, playerLevel[30];
+        for (new player = 0; player <= PlayerManager->highestPlayerId(); player++) {
+            if (!Player(player)->isConnected()) continue;
+            if (!Player(player)->isVip()) continue;
+            if (IsPlayerAdmin(player)) continue;
+
+            
+    
+            if (Player(player)->isVip())
+                format(playerLevel, sizeof(playerLevel), "VIP");
+            if (Player(player)->isDeveloper())
+                format(playerLevel, sizeof(playerLevel), "VIP / Developer");          
+            if (Player(player)->isAdministrator() && !Player(player)->isManagement())
+                format(playerLevel, sizeof(playerLevel), "VIP / Administrator");  
+            if (Player(player)->isManagement())
+                format(playerLevel, sizeof(playerLevel), "Manager");    
+            
+            // Format the message for any general player.
+            format(message, sizeof(message), " %s (Id:%d) - {FFFF00}%s", Player(player)->nicknameString(),
+                player, playerLevel);
+            
+            
+
+
+            SendClientMessage(playerid, Color::Information, message);
+            vipCount++;
+            }
+
+            if (vipCount == 0)
+                SendClientMessage(playerid, Color::Information, "No VIPs are currently online in LVP.");
+
+            return 1;    
+        }
+
 
     if (strcmp(cmd, "/cardive", true) == 0) {
         if ((Time->currentTime() - iDiveTime[playerid]) < 3 * 60 && !Player(playerid)->isAdministrator()) {

--- a/pawn/Resources/Callbacks/OnPlayer/OnPlayerCommandText.pwn
+++ b/pawn/Resources/Callbacks/OnPlayer/OnPlayerCommandText.pwn
@@ -928,7 +928,6 @@ public OnPlayerCommandText(playerid, cmdtext[]) {
             if (IsPlayerAdmin(player)) continue;
 
             
-    
             if (Player(player)->isVip())
                 format(playerLevel, sizeof(playerLevel), "VIP");
             if (Player(player)->isDeveloper())
@@ -943,8 +942,7 @@ public OnPlayerCommandText(playerid, cmdtext[]) {
                 player, playerLevel);
             
             
-
-
+            
             SendClientMessage(playerid, Color::Information, message);
             vipCount++;
             }


### PR DESCRIPTION
Change in /admins and addition of /vips.

Tested.

Change in /admins
I have added a level Temp. Admin in /admins for players to differentiate full-time admins and part-time, Since temp admins operate at limited power. I felt this knowledge should be transparent to fellow players. Tested it thoroughly. And admins can see who temp'ed the person while players only see temp-admin. Also, added Developers to this list since it was long overdue? What do you think?

Addition of /vips

Just similar to /admins but shows also higher level (i.e) VIP, Developer, Administrator, and Manager. 

