### PR TITLE
Bringing pickups to Las Venturas

### DIFF
--- a/pawn/Features/Deathmatch/StatuesManager.pwn
+++ b/pawn/Features/Deathmatch/StatuesManager.pwn
@@ -49,10 +49,10 @@ class StatuesManager {
     // Gather all the statues info in one array.
     new m_statueInfo[4][statueDetails] = {
         //    posX        posY     posZ  sModelId  iconId                  mapId   statueId
-        {2845.6782, -2410.4414, 19.1922,     1254,      6,     DynamicMapIcon: 0,        -1}, // Ammo Statue
-        { -689.293,   1538.472,  82.685,     1242,     30,     DynamicMapIcon: 0,        -1}, // Armour Statue
-        {-2870.233,   2803.545, 250.589,     1240,     22,     DynamicMapIcon: 0,        -1}, // Health Statue
-        {-2611.399,  -2851.273,   2.863,     1274,     23,     DynamicMapIcon: 0,        -1}  // Money Statue
+        {2157.2881,   963.3771, 10.8203,     1254,      6,     DynamicMapIcon: 0,        -1}, // Ammo Statue
+        {1088.5408,  1074.3296, 10.8359,     1242,     30,     DynamicMapIcon: 0,        -1}, // Armour Statue
+        {1579.5760,  1768.7635, 10.8203,     1240,     22,     DynamicMapIcon: 0,        -1}, // Health Statue
+        {2438.3457,  2376.2471, 10.8203,     1274,     23,     DynamicMapIcon: 0,        -1}  // Money Statue
     };
 
     /**


### PR DESCRIPTION
Thank you for making a contribution to [Las Venturas Playground](https://sa-mp.nl/)!

Please take a moment to fill in the questions in this template, to make it easier for our developers
to understand what you're doing.

## What is being changed?
StatuesManager.pwn

## Why is this being changed?
They were located far away at the corners of the map. 
I have only seen non registered players going for it as most of them prefer freeroam, As the server called "Las Venturas Playground"  So I guess it will be more sensible to bring them in LV???

**BEFORE**
![sa-mp-052](https://user-images.githubusercontent.com/65241998/108618292-fa3e9100-7442-11eb-9a67-e042808d09c7.png)

**AFTER**
![sa-mp-051](https://user-images.githubusercontent.com/65241998/108618298-07f41680-7443-11eb-9dc6-162ecbb6cacb.png)
![sa-mp-050](https://user-images.githubusercontent.com/65241998/108618300-0d516100-7443-11eb-8006-0ed5d8caabc9.png)
![sa-mp-048](https://user-images.githubusercontent.com/65241998/108618314-19d5b980-7443-11eb-936f-cbb700822d70.png)
![sa-mp-047](https://user-images.githubusercontent.com/65241998/108618322-26f2a880-7443-11eb-8346-b1414be95e5b.png)
![sa-mp-049](https://user-images.githubusercontent.com/65241998/108618404-db8cca00-7443-11eb-88f0-cae2b128e54e.png)






